### PR TITLE
chore: enable publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       - develop
 
 env:
-  ENABLE_PUBLISHING: false # Set to true to enable publishing
+  ENABLE_PUBLISHING: true # Set to true to enable publishing
   TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} #
   PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }} # Set your PyPI API token in GitHub secrets
 jobs:


### PR DESCRIPTION
# Enable Publishing Packages

## Summary
This PR enables publishing in the GitHub Actions workflow by updating the `ENABLE_PUBLISHING` environment variable.

## Files Changed
- **.github/workflows/publish.yml**: Changed the `ENABLE_PUBLISHING` setting from `false` to `true`.

## Code Changes
In `.github/workflows/publish.yml`:
```yaml
-  ENABLE_PUBLISHING: false # Set to true to enable publishing
+  ENABLE_PUBLISHING: true # Set to true to enable publishing
```
This change activates the publishing functionality in the workflow.

## Reason for Changes
The change is made to enable automated publishing of the project to PyPI or TestPyPI as part of the CI/CD pipeline, facilitating easier distribution and testing of the package.

## Impact of Changes
Enabling publishing will automate the release process, potentially affecting deployment frequency and package availability. It ensures that builds on specified branches (`main` and `develop`) can publish packages if other conditions in the workflow are met.

## Test Plan
Verify the workflow runs successfully on the next push to `main` or `develop` branches. Check if the package is published to TestPyPI or PyPI as configured, and ensure no unauthorized access or token leaks occur during the process.

## Additional Notes
Ensure that the `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN` secrets are correctly set in the GitHub repository settings to avoid authentication issues during publishing.
